### PR TITLE
Use flexible flow-bin dependency version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "babel-plugin-transform-flow-comments": "^6.17.0",
-    "flow-bin": "^0.33.0"
+    "flow-bin": ">=0.33 <1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Will match any 0.x release greater than or equal to 0.33, which I assume was the intention of `^0.33.0` (which doesn’t work because 0.x releases in semver aren’t assured to be non-breaking).