### PR TITLE
fix: duplicate output when pushError is called multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,8 +67,6 @@ function flowErrorCode(status) {
 
 
 function checkFlowStatus(compiler, next) {
-  store.error = null;
-
   var res = spawnSync(flow, store.flowOptions);
   var status = res.status;
 
@@ -85,6 +83,8 @@ function checkFlowStatus(compiler, next) {
 function pushError(compilation) {
   if (store.error) {
     compilation.errors.push(store.error);
+
+    store.error = null;
   }
 }
 


### PR DESCRIPTION
Hey, I was having an issue where I got the same flow error multiple times in the console.
I debugged it and it turns out it was because pushError was being called multiple times without clearing `store.error`.

I fixed it and moved the clearing code to `pushError` instead of copying it since nothing in `checkFlowStatus` reads from `store.error`.