### PR TITLE
feat: add option to output warnings instead of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ From now on, when you run webpack, you will recieve flow status reports alongsid
 Something like this.
 ![](/demo.png)
 
+#### Options
+
+It should work pretty well with the defaults, but there are some options available:
+
+##### warn
+
+If you'd prefer to treat Flow issues as webpack warnings instead of errors, you can enable this option.
+
+```js
+plugins: [
+  new FlowBabelWebpackPlugin({
+    warn: true,
+  }),
+],
+```
+
 ---
 
 ### What's next?

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var spawnSync = require('child_process').spawnSync;
 var flow = require('flow-bin');
+var merge = require('lodash.merge');
 
 var store = {
   error: null,
@@ -7,6 +8,9 @@ var store = {
     'status',
     '--color=always',
   ],
+  options: {
+    warn: false,
+  },
 };
 
 
@@ -84,12 +88,18 @@ function checkFlowStatus(compiler, next) {
 
 function pushError(compilation) {
   if (store.error) {
-    compilation.errors.push(store.error);
+    if (store.options.warn) {
+      compilation.warnings.push(store.error);
+    } else {
+      compilation.errors.push(store.error);
+    }
   }
 }
 
 
-function FlowFlowPlugin() {}
+function FlowFlowPlugin(options) {
+  store.options = merge(store.options, options);
+}
 
 FlowFlowPlugin.prototype.apply = function(compiler) {
   compiler.plugin('run', checkFlowStatus);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "babel-plugin-transform-flow-comments": "^6.17.0",
-    "flow-bin": ">=0.33 <1"
+    "flow-bin": ">=0.33 <1",
+    "lodash.merge": "^4.6.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
We're starting to adopt Flow in our development process and would prefer it if Flow errors don't break our webpack builds while we transition, so I added this option to output warnings instead.