### PR TITLE
Remove extra errors.push call

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,8 +97,6 @@ function pushError(compilation) {
       compilation.errors.push(store.error);
     }
 
-    compilation.errors.push(store.error);
-
     store.error = null;
   }
 }


### PR DESCRIPTION
Removed extra errors.push which was being called even when warn was set to true, and therefore threw an error instead of a warning.