### PR TITLE
feat: accept flow status command options in plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ plugins: [
 ],
 ```
 
+##### flowOptions
+You can provide flow status command options.
+
+For example:
+
+```js
+plugins: [
+  new FlowBabelWebpackPlugin({
+    flowOptions: {
+      color: 'auto',
+      'one-line': true,
+      'include-warnings': true,
+    },
+  }),
+],
+```
+
 ---
 
 ### What's next?

--- a/index.js
+++ b/index.js
@@ -6,8 +6,10 @@ var store = {
   error: null,
   flowOptions: [
     'status',
-    '--color=always',
   ],
+  flowStatusOptions: {
+    color: 'always'
+  },
   options: {
     warn: false,
 
@@ -102,7 +104,27 @@ function pushError(compilation) {
 }
 
 
+function normalizeFlowOptions(flowOptions) {
+  return Object.keys(flowOptions)
+               .filter(function(key) {
+                 return flowOptions[key] !== false;
+               })
+               .map(function(key) {
+                 return flowOptions[key] === true ?
+                     `--${key}` :
+                     `--${key}=${flowOptions[key]}`;
+               });
+}
+
+
 function FlowFlowPlugin(options) {
+  if (options && options.flowOptions) {
+    store.flowStatusOptions =
+        merge(store.flowStatusOptions, options.flowOptions);
+    delete options.flowOptions;
+  }
+  store.flowOptions =
+      store.flowOptions.concat(normalizeFlowOptions(store.flowStatusOptions));
   store.options = merge(store.options, options);
 }
 


### PR DESCRIPTION
This feature provide a way to specify flow-bin status command options.