### PR TITLE
Stop flow servers started by this plugin by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ plugins: [
 ],
 ```
 
+##### stopStartedServer
+
+You can choose to keep the flow server started by this plugin running by setting this to `false`. Default is `true`.
+
+Note that pre-started flow servers are reused and never stopped by this plugin.
+
+For example:
+```js
+plugins: [
+  new FlowBabelWebpackPlugin({
+    stopStartedServer: false,
+  }),
+],
+```
 ---
 
 ### What's next?


### PR DESCRIPTION
 - By default, flow servers started by this plugin are stopped
 - Setting options.stopStartedServer = false disables this behavior
 - Pre-started flow server processes are always left alone

The rationale behind this change is that the leaked processes cause major problems on machines that run this plugin on a large number of projects.

The added `--quiet` flag on line 10 seems to address #16 .